### PR TITLE
Allow easy access to the transports layers

### DIFF
--- a/sinstruments/simulator.py
+++ b/sinstruments/simulator.py
@@ -179,7 +179,7 @@ class SerialServer(SimulatorServerMixin):
     """
 
     def __init__(self, name, handler, **kwargs):
-        self.address = kwargs.pop("url")
+        self.address = kwargs.pop("url", '')
         self.set_listener(kwargs.pop('listener', None))
         SimulatorServerMixin.__init__(self, name, handler, **kwargs)
 

--- a/sinstruments/simulator.py
+++ b/sinstruments/simulator.py
@@ -398,6 +398,7 @@ class Server(object):
         self._log.info("Creating device %s (%r)", name, klass_name)
         device_info["server"] = self
         device, transports = create_device(device_info)
+        self.dev_transport[name] = (device, transports)
         self.devices[device] = transports
         return device, transports
 


### PR DESCRIPTION
Allow to access to the device transports layers and remove the URL as mandatory parameter to create easy test with pytest. 